### PR TITLE
Add support for Vue stories …

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 [![Total Download](https://img.shields.io/npm/dt/storybook-addon-jsx.svg)](https://www.npmjs.com/package/storybook-addon-jsx)
 [![Current Version](https://img.shields.io/npm/v/storybook-addon-jsx.svg)](https://www.npmjs.com/package/storybook-addon-jsx)
 
-This Storybook addon show you the JSX of the story.
-It can be usefull to see what props you set for example.
+This Storybook addon shows you the JSX of the story.
+It can be useful to see what props you set, for example.
 
 ![Storybook Addon JSX Démo](screenshot.png)
 
@@ -55,6 +55,22 @@ storiesOf('test', module)
 storiesOf('test 2', module).addWithJSX('Paris', () => (
   <div color="#333">test</div>
 ));
+```
+
+You can also configure globally:
+```js
+import { configure, setAddon } from '@storybook/vue';
+
+setAddon(JSXAddon);
+
+configure(loadStories, module);
+```
+
+```js
+import { storiesOf } from '@storybook/vue';
+
+storiesOf('Vue', module)
+  .addWithJSX('template property', () => ({ template: `<div></div>` }));
 ```
 
 ## Options

--- a/src/index.js
+++ b/src/index.js
@@ -50,8 +50,15 @@ export default {
 
     const result = this.add(kind, context => {
       const story = storyFn(context)
+      let jsx = ''
 
-      const jsx = renderJsx(story, options)
+      if (story.template) {
+        jsx = story.template
+      }
+      else {
+        jsx = renderJsx(story, options)
+      }
+
       channel.emit('kadira/jsx/add_jsx', result.kind, kind, jsx)
 
       return story


### PR DESCRIPTION
…that use the form .addWithJSX('Default', () => ({ template: `<br />` });

This is such a minor, but useful, change that I don't think it merits a fork. I'd be happy to lend a hand maintaining Vue support.

I tried to add tests but tapped out after trying to get jest to play nice with storybook/vue (cf. [diff](https://github.com/storybooks/addon-jsx/compare/master...Alfredo-Delgado:add-vue-template-support-tests?expand=1))

local sample results:
![screen shot 2018-01-03 at 3 12 55 pm](https://user-images.githubusercontent.com/798836/34541804-b5053b38-f0a7-11e7-8f4e-c72f3f8cf6f9.png)
