### PR TITLE
feat(render-jsx): add onBeforeRender option to manipulate jsx render output

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,34 @@ storiesOf('test 2', module).addWithJSX(
 // <Test>Hello</Test>
 ```
 
+- `onBeforeRender(domString: string) => string` (default: undefined) : function that receives the dom as a string before render.
+
+```js
+/Option onBeforeRender
+storiesOf('test 2', module).addWithJSX(
+  'Paris',
+  () => (
+    <div color="#333">
+      <div dangerouslySetInnerHTML={{ __html: '<div>Inner HTML</div>',}} />
+    </div>
+  ),
+  {
+    onBeforeRender: domString => {
+      if (domString.search('dangerouslySetInnerHTML') < 0) {
+        return ''
+      }
+      try {
+        domString = /(dangerouslySetInnerHTML={{)([^}}]*)/.exec(domString)[2]
+        domString = /(')([^']*)/.exec(domString)[2]
+      } catch (err) {}
+      return domString
+    },
+  },
+);
+// Output
+// <div>Inner HTML</div>
+```
+
 #### Not JSX
 
 If a Vue story defines its view with a template string then it will be displayed

--- a/example/stories/withProps.js
+++ b/example/stories/withProps.js
@@ -46,4 +46,27 @@ export default () =>
         </Simple>
       ),
       { skip: 1, displayName: () => 'Renamed' },
+    )
+    .addWithJSX(
+      'With dangerouslySetInnerHTML - onBeforeRender',
+      () => (
+        <Simple>
+          <Simple test="test" value={true}>
+            <div dangerouslySetInnerHTML={{ __html: '<div>Inner HTML<ul><li>1</li><li>2</li></ul></div>',}} />
+          </Simple>
+        </Simple>
+      ),
+      {
+        skip: 1,
+        onBeforeRender: domString => {
+          if (domString.search('dangerouslySetInnerHTML') < 0) {
+            return ''
+          }
+          try {
+            domString = /(dangerouslySetInnerHTML={{)([^}}]*)/.exec(domString)[2]
+            domString = /(')([^']*)/.exec(domString)[2]
+          } catch (err) {}
+          return domString
+        },
+      },
     );

--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -313,3 +313,23 @@ exports[`Storyshots With Props With children - Skip and rename 1`] = `
   </div>
 </div>
 `;
+
+exports[`Storyshots With Props With dangerouslySetInnerHTML - onBeforeRender 1`] = `
+<div>
+  <span>
+    Hello
+  </span>
+  <div>
+    <span>
+      Hello
+    </span>
+    <div
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "<div>Inner HTML<ul><li>1</li><li>2</li></ul></div>",
+        }
+      }
+    />
+  </div>
+</div>
+`;

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,14 @@
 import React from 'react'
 import addons from '@storybook/addons'
 import reactElementToJSXString from 'react-element-to-jsx-string'
-import { html as beautifyHTML } from 'js-beautify';
+import { html as beautifyHTML } from 'js-beautify'
+
+const applyBeforeRender = (domString, options) => {
+  if (typeof options.onBeforeRender !== 'function') {
+    return domString
+  }
+  return options.onBeforeRender(domString)
+}
 
 const renderJsx = (code, options) => {
   for (let i = 0; i < options.skip; i++) {
@@ -37,7 +44,9 @@ const renderJsx = (code, options) => {
       ? Object.assign({}, options, { showFunctions: true, displayName: () => options.displayName })
       : options
 
-  return React.Children.map(code, c => reactElementToJSXString(c, ooo)).join('\n')
+  return React.Children.map(code, c =>
+    applyBeforeRender(reactElementToJSXString(c, ooo), options),
+  ).join('\n')
 }
 
 export default {


### PR DESCRIPTION
Hello,
addon-jsx is a quite cool addon for storybook and updates the documentation without any effort.
Thanks a lot for it 👍 

This PR will add a function `onBeforeRender` to the options and can be used to manipulate the render output. For example, this is needed if you render server-rendered markup (with a webpack-loader) as dangerouslySetInnerHTML. The storybook consumer is just interested in the innerHTML part.

Thanks in advance 😄  